### PR TITLE
refactor(tests): centralize cache management and improve maintainability

### DIFF
--- a/src/Console/ModelFieldsCommand.php
+++ b/src/Console/ModelFieldsCommand.php
@@ -8,6 +8,8 @@ use WatheqAlshowaiter\ModelFields\Fields;
 
 class ModelFieldsCommand extends Command
 {
+    const STAR_PROMPT_CACHE_KEY = 'model-fields.github_star_prompted';
+
     protected $signature = 'model:fields
                            {model : The model class name (e.g., User, App\\Models\\Post)}
                            {--a|all : Get all fields}
@@ -208,7 +210,7 @@ class ModelFieldsCommand extends Command
             return;
         }
 
-        $cacheKey = 'model-fields.banner_shown';
+        $cacheKey = self::STAR_PROMPT_CACHE_KEY;
         $repo = 'https://github.com/WatheqAlshowaiter/model-fields';
 
         if (Cache::get($cacheKey)) {

--- a/tests/ModelFieldsCommandTest.php
+++ b/tests/ModelFieldsCommandTest.php
@@ -6,7 +6,6 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use InvalidArgumentException;
 use RuntimeException;
-use Symfony\Component\Console\Command\Command;
 use WatheqAlshowaiter\ModelFields\Console\ModelFieldsCommand;
 use WatheqAlshowaiter\ModelFields\Tests\Models\Father;
 
@@ -17,6 +16,18 @@ class ModelFieldsCommandTest extends TestCase
     public const SUCCESS_EXIT_CODE = 0;
 
     public const FAILURE_EXIT_CODE = 1;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::forever(ModelFieldsCommand::STAR_PROMPT_CACHE_KEY, true);
+    }
+
+    protected function tearDown(): void
+    {
+        Cache::forget(ModelFieldsCommand::STAR_PROMPT_CACHE_KEY);
+        parent::tearDown();
+    }
 
     public function test_error_when_no_model_provided()
     {
@@ -55,12 +66,11 @@ class ModelFieldsCommandTest extends TestCase
 
     public function test_use_list_format_when_not_provided()
     {
-        Cache::forever('model-fields.banner_shown', true);
+        Cache::forever(ModelFieldsCommand::STAR_PROMPT_CACHE_KEY, true);
 
         $this->artisan('model:fields', ['model' => Father::class])
             ->assertExitCode(self::SUCCESS_EXIT_CODE);
 
-        Cache::forget('model-fields.banner_shown');
     }
 
     public function test_fail_when_provided_more_than_one_field_type()
@@ -76,8 +86,6 @@ class ModelFieldsCommandTest extends TestCase
 
     public function test_default_to_all_fields_when_no_type_specified()
     {
-        Cache::forever('model-fields.banner_shown', true);
-
         $this->artisan('model:fields', [
             'model' => Father::class,
         ])
@@ -90,14 +98,10 @@ class ModelFieldsCommandTest extends TestCase
             ->expectsOutput('  - created_at')
             ->expectsOutput('  - updated_at')
             ->expectsOutput('  - deleted_at');
-
-        Cache::forget('model-fields.banner_shown');
     }
 
     public function test_uses_type_when_specified()
     {
-        Cache::forever('model-fields.banner_shown', true);
-
         $this->artisan('model:fields', [
             'model' => Father::class,
             '--required' => true,
@@ -105,14 +109,10 @@ class ModelFieldsCommandTest extends TestCase
             ->expectsOutput('Father required fields:')
             ->expectsOutput('  - name')
             ->expectsOutput('  - email');
-
-        Cache::forget('model-fields.banner_shown');
     }
 
     public function test_uses_type_shortname_when_specified()
     {
-        Cache::forever('model-fields.banner_shown', true);
-
         $this->artisan('model:fields', [
             'model' => Father::class,
             '-r' => true,
@@ -120,14 +120,10 @@ class ModelFieldsCommandTest extends TestCase
             ->expectsOutput('Father required fields:')
             ->expectsOutput('  - name')
             ->expectsOutput('  - email');
-
-        Cache::forget('model-fields.banner_shown');
     }
 
     public function test_json_format()
     {
-        Cache::forever('model-fields.banner_shown', true);
-
         $this->artisan('model:fields', [
             'model' => Father::class,
             '--nullable' => true,
@@ -139,14 +135,10 @@ class ModelFieldsCommandTest extends TestCase
     "updated_at",
     "deleted_at"
 ]');
-
-        Cache::forget('model-fields.banner_shown');
     }
 
     public function test_table_format()
     {
-        Cache::forever('model-fields.banner_shown', true);
-
         $this->artisan('model:fields', [
             'model' => Father::class,
             '--primary' => true,
@@ -157,64 +149,48 @@ class ModelFieldsCommandTest extends TestCase
             ->expectsOutput('+-----------------------+')
             ->expectsOutput('| id                    |')
             ->expectsOutput('+-----------------------+');
-
-        Cache::forget('model-fields.banner_shown');
     }
 
     public function test_json_format_with_empty_results()
     {
-        Cache::forever('model-fields.banner_shown', true);
-
         $this->artisan('model:fields', [
             'model' => Father::class,
             '-A' => true,
             '--format' => 'json',
         ])->expectsOutput('No app-default fields found for Father model.');
-
-        Cache::forget('model-fields.banner_shown');
     }
 
     public function test_table_format_with_empty_results()
     {
-        Cache::forever('model-fields.banner_shown', true);
-
         $this->artisan('model:fields', [
             'model' => Father::class,
             '-A' => true,
             '--format' => 'table',
         ])->expectsOutput('No app-default fields found for Father model.');
-
-        Cache::forget('model-fields.banner_shown');
     }
 
     public function test_list_format_with_empty_results()
     {
-        Cache::forever('model-fields.banner_shown', true);
-
         $this->artisan('model:fields', [
             'model' => Father::class,
             '-A' => true,
         ])->expectsOutput('No app-default fields found for Father model.');
-
-        Cache::forget('model-fields.banner_shown');
     }
 
     public function test_does_not_ask_if_already_cached()
     {
-        Cache::forever('model-fields.banner_shown', true);
+        Cache::forever(ModelFieldsCommand::STAR_PROMPT_CACHE_KEY, true); // make it clear here
 
         $this->artisan('model:fields', [
             'model' => Father::class,
         ])->assertExitCode(0);
 
-        $this->assertTrue(Cache::get('model-fields.banner_shown'));
-
-        Cache::forget('model-fields.banner_shown');
+        $this->assertTrue(Cache::get(ModelFieldsCommand::STAR_PROMPT_CACHE_KEY));
     }
 
     public function test_asks_and_user_declines()
     {
-        Cache::forget('model-fields.banner_shown');
+        Cache::forget(ModelFieldsCommand::STAR_PROMPT_CACHE_KEY);
 
         $this->artisan('model:fields', [
             'model' => Father::class,
@@ -222,13 +198,12 @@ class ModelFieldsCommandTest extends TestCase
             ->expectsQuestion('🌟 Help other developers find this package by starring it on GitHub?', false)
             ->assertExitCode(self::SUCCESS_EXIT_CODE);
 
-        $this->assertTrue(Cache::get('model-fields.banner_shown'));
-        Cache::forget('model-fields.banner_shown');
+        $this->assertTrue(Cache::get(ModelFieldsCommand::STAR_PROMPT_CACHE_KEY));
     }
 
     public function test_asks_and_user_accepts()
     {
-        Cache::forget('model-fields.banner_shown');
+        Cache::forget(ModelFieldsCommand::STAR_PROMPT_CACHE_KEY);
 
         // Create a subclass that overrides openUrl()
         $stubCommand = new class extends ModelFieldsCommand
@@ -254,7 +229,5 @@ class ModelFieldsCommandTest extends TestCase
             ->assertExitCode(self::SUCCESS_EXIT_CODE);
 
         $this->assertStringContainsString('github.com/WatheqAlshowaiter/model-fields', $stubCommand->calledWith);
-
-        Cache::forget('model-fields.banner_shown');
     }
 }


### PR DESCRIPTION
- Add STAR_PROMPT_CACHE_KEY constant to ModelFieldsCommand
- Centralize cache setup/teardown in test base methods
- Remove repetitive cache operations from individual tests
- Remove unused Symfony Command import